### PR TITLE
Fix/set service constructor arguments with the service definition object.

### DIFF
--- a/DependencyInjection/IkoeneMarvelApiExtension.php
+++ b/DependencyInjection/IkoeneMarvelApiExtension.php
@@ -18,13 +18,14 @@ class IkoeneMarvelApiExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('marvel.public_api_key', $config['public_api_key']);
-        $container->setParameter('marvel.private_api_key', $config['private_api_key']);
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../Resources/config')
         );
         $loader->load('services.yml');
+
+        $container->getDefinition('ikoene_marvel_api_client')
+            ->setArgument(0, $config['public_api_key'])
+            ->setArgument(1, $config['private_api_key']);
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,3 @@ services:
     ikoene_marvel_api_client:
         class: Ikoene\MarvelApiBundle\Controller\Client
         public: true
-        arguments:
-            - '%marvel.public_api_key%'
-            - '%marvel.private_api_key%'


### PR DESCRIPTION
## Description

Set service `ikoene_marvel_api_client` constructor arguments with the service definition object. Definition objects define how a service will be instantiated.

Fixes #1